### PR TITLE
Complete C-NaturalDates

### DIFF
--- a/src/main/java/duke/DateTimeParser.java
+++ b/src/main/java/duke/DateTimeParser.java
@@ -4,36 +4,127 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DateTimeParser {
+    private static final LocalDateTime DEFAULT = LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT);
+    private static final String[] acceptedDatePatterns = {
+            "d/M/yyyy",
+            "d/M/yy",
+            "d/M",
+            "d M yyyy",
+            "d M yy",
+            "d M",
+            "d LLL",
+            "d LLL yy",
+            "d LLL yyyy",
+            "d LLLL",
+            "d LLLL yy",
+            "d LLLL yyyy"
+    };
+    private static final String[] acceptedTimePatterns = {
+            "HHmm",   //2359
+            "h:m",    //1:30
+            "h:m a",  //1:30 PM
+            "h:ma",   //1:30PM
+            "h a",    //12 PM
+            "ha",     //12PM
+            "h"       //12
+    };
+
+    private static LocalDateTime parseInputWithAcceptedPatterns(String inputDate, String[] acceptedPatterns) {
+        TemporalAccessor t = null;
+        DateTimeFormatter dtf = null;
+        for (String pattern : acceptedPatterns) {
+            dtf = new DateTimeFormatterBuilder()
+                    .parseCaseInsensitive()
+                    .appendPattern(pattern)
+                    .toFormatter();
+            try {
+                t = dtf.parse(inputDate);
+                break;
+            } catch (DateTimeParseException e) {
+                continue;
+            }
+        }
+        if (t == null) {
+            throw new DateTimeParseException("Unable to parse date!", inputDate, 0);
+        }
+
+        LocalDateTime result = DEFAULT;
+        for (ChronoField field : ChronoField.values()) {
+            if (t.isSupported(field)) {
+                result = result.with(field, t.getLong(field));
+            }
+        }
+        return result;
+    }
+
+
+
     /**
-     * Parses a given input string into a LocalDateTime object. The format of the input can be in either formats below.
-     * dd/MM/yyyy HHmm
-     * HHmm
-     * dd/MM/yyyy 
-     * If input is given in HHmm format, the parser will default to the input time on current system date.
-     * If input is given in dd/MM/yyyy format, the parser will default to 0000 on the input date.
-     * 
+     * Parses a given input string into a LocalDateTime object.
+     * Supports many date and time formats.
+     * Date and times entered are case-insensitive.
+     *
+     * Supported date formats are:
+     *             "d/M/yyyy",
+     *             "d/M/yy",
+     *             "d/M",
+     *             "d M yyyy",
+     *             "d M yy",
+     *             "d M",
+     *             "d LLL",
+     *             "d LLL yy",
+     *             "d LLL yyyy",
+     *             "d LLLL",
+     *             "d LLLL yy",
+     *             "d LLLL yyyy"
+     *
+     * Supported time formats are:
+     *             "HHmm",   //2359
+     *             "h:m",    //1:30
+     *             "h:m a",  //1:30 PM
+     *             "h:ma",   //1:30PM
+     *             "h a",    //12 PM
+     *             "ha",     //12PM
+     *             "h"       //12
+     *
+     * Any combination of dateFormat + timeFormat, separated with a space, is also accepted.
+     * Eg: 1 jan 2023 1:30pm
+     * Combination of "d LLL yyyy" + "h:ma"
+     *
      * @param dateTime String to be format into LocalDateTime object.
      * @throws DateTimeParseException Thrown when parser is unable to format input string
      * @return LocalDateTime object corresponding to the input string
      */
     public static LocalDateTime parseInput(String dateTime) throws DateTimeParseException {
         try {
-            return LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("dd/MM/yyyy HHmm"));
-        } catch (DateTimeParseException e) { }
+            return parseInputWithAcceptedPatterns(dateTime, acceptedDatePatterns);
+        } catch (DateTimeParseException e) {
+            //No error, try to parse as time first
+        }
         try {
-            LocalTime time = LocalTime.parse(dateTime, DateTimeFormatter.ofPattern("HHmm"));
-            LocalDateTime dt = time.atDate(LocalDate.now());
-            return dt;
-        } catch (DateTimeParseException e) { }
+            return parseInputWithAcceptedPatterns(dateTime, acceptedTimePatterns);
+        } catch (DateTimeParseException e) {
+            //No error, try to parse as DateTime first
+        }
         try {
-            LocalDate date = LocalDate.parse(dateTime, DateTimeFormatter.ofPattern("dd/MM/yyyy"));
-            LocalDateTime dt = date.atTime(LocalTime.of(0, 0));
-            return dt;
-        } catch (DateTimeParseException e) { }
-        throw new DateTimeParseException("Unable to parse datetime", dateTime, 0);
+            List<String> l = new ArrayList<>();
+            for (String datePattern : acceptedDatePatterns) {
+                for (String timePattern : acceptedTimePatterns) {
+                    l.add(datePattern + " " + timePattern);
+                }
+            }
+            return parseInputWithAcceptedPatterns(dateTime, l.toArray(new String[0]));
+        } catch (DateTimeParseException e) {
+            throw new DateTimeParseException("Unable to parse input date time!", dateTime, 0);
+        }
     }
 
     /**


### PR DESCRIPTION
Duke can only understand dates in a few very specific formats.

This is unintuitive for the user and many more natural dates cannot be entered.

Lets update DateTimeParser to allow Duke to understand many more datetime formats. We add a list of acceptable dates and time formats into separate arrays. Duke then tries to format a given input against any of those formats. If none match, Duke combines the dates and time formats and tries to format the inputs again.

This allows us to easily add new supported date time formats in the future.